### PR TITLE
Update SimpleBlogCategories.php

### DIFF
--- a/SimpleBlogCategories.php
+++ b/SimpleBlogCategories.php
@@ -48,6 +48,8 @@ class BlogCategories extends SimpleBlog{
 
 
 		$parts[1] = str_replace('_',' ',$parts[1]);
+		if (array_key_exists($parts[1],$this->categories)){
+		 return $parts[1];}
 		return array_search($parts[1],$this->categories);
 	}
 


### PR DESCRIPTION
for examlpe url  /Blog_Categories/a   not set $this->catindex  and do not show category posts, cause in  $this->categories,  $parts[1] its a value of key, so array_search retutn false.

edit. I found that it happens only when url types in settings set to Blog/1234
so  maybe in  function CategoryLink

> case 'Tiny':
>               $url .= '/'.$catindex;
>     >       break;

should be 

> case 'Tiny':
>               $cattitle = str_replace(array('?',' '),array('','_'),$cattitle);
>               $url .= '/'.$cattitle;
>           break;
